### PR TITLE
chore: add placeholder test scripts

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -9,6 +9,7 @@
     "web": "expo start --web",
     "dev": "expo start --dev-client",
     "build": "expo build",
+    "test": "echo \"No tests specified\" && exit 0",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "test": "echo \"No tests specified\" && exit 0",
     "lint": "eslint src --ext .ts"
   },
   "dependencies": {

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -12,7 +12,7 @@
     "db:seed": "tsx src/seed.ts",
     "db:studio": "prisma studio",
     "db:generate": "prisma generate",
-    "test": "jest",
+    "test": "jest --passWithNoTests",
     "lint": "eslint src --ext .ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- ensure API tests pass without files
- add placeholder test scripts for mobile and shared packages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adbfc28740832aaa4ec8b20d41bfd1